### PR TITLE
Update reproc

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
 Checks:
 '
 *,
+-altera-struct-pack-align,
 -android-cloexec-fopen,
 -android-cloexec-pipe,
 -bugprone-exception-escape,
@@ -9,6 +10,7 @@ Checks:
 -cert-*,
 -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
 -clang-diagnostic-unused-command-line-argument,
+-concurrency-mt-unsafe,
 -cppcoreguidelines-avoid-c-arrays,
 -cppcoreguidelines-avoid-magic-numbers,
 -cppcoreguidelines-macro-usage,
@@ -28,7 +30,9 @@ Checks:
 -misc-no-recursion,
 -modernize-avoid-c-arrays,
 -modernize-use-trailing-return-type,
+-performance-no-int-to-ptr,
 -readability-else-after-return,
+-readability-function-cognitive-complexity,
 -readability-magic-numbers,
 '
 HeaderFilterRegex: '.*reproc\+\+.*$'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             compiler: gcc
 
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             compiler: clang
 
           - os: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 14.2.3
+
+- Bugfix: Fix sign of EWOULDBLOCK error returned from `reproc_read`.
+
 ## 14.2.2
 
 - Bugfix: Disallow using `fork` option when using `reproc_run`.

--- a/reproc/src/reproc.c
+++ b/reproc/src/reproc.c
@@ -488,7 +488,7 @@ int reproc_read(reproc_t *process,
     reproc_event_source source = { process, event, 0 };
     r = reproc_poll(&source, 1, process->nonblocking ? 0 : REPROC_INFINITE);
     if (r <= 0) {
-      return r == 0 ? -REPROC_EWOULDBLOCK : r;
+      return r == 0 ? REPROC_EWOULDBLOCK : r;
     }
   }
 


### PR DESCRIPTION
The latest version (14.2.3) fixes a bug on Windows. This bug effectively causes subprocess module to misintepret return value from `reproc_read` causing a memory leak.